### PR TITLE
Deep free concatenated search name rdf

### DIFF
--- a/resolver.c
+++ b/resolver.c
@@ -1108,7 +1108,8 @@ ldns_resolver_search_status(ldns_pkt** pkt,
 
 			s = ldns_resolver_query_status(pkt, r,
 					new_name, t, c, flags);
-			ldns_rdf_free(new_name);
+			ldns_rdf_deep_free(new_name);
+
 			if (pkt && *pkt) {
 				if (s == LDNS_STATUS_OK && 
 						ldns_pkt_get_rcode(*pkt) ==


### PR DESCRIPTION
Before this fix:
```
valgrind examples/.libs/ldns-mx gmail.com
==17889== Memcheck, a memory error detector
==17889== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==17889== Using Valgrind-3.12.0.SVN and LibVEX; rerun with -h for copyright info
==17889== Command: examples/.libs/ldns-mx gmail.com
==17889== 
gmail.com.      3599    IN      MX      5 gmail-smtp-in.l.google.com.
gmail.com.      3599    IN      MX      10 alt1.gmail-smtp-in.l.google.com.
gmail.com.      3599    IN      MX      20 alt2.gmail-smtp-in.l.google.com.
gmail.com.      3599    IN      MX      30 alt3.gmail-smtp-in.l.google.com.
gmail.com.      3599    IN      MX      40 alt4.gmail-smtp-in.l.google.com.
==17889== 
==17889== HEAP SUMMARY:
==17889==     in use at exit: 38 bytes in 2 blocks
==17889==   total heap usage: 502 allocs, 500 frees, 615,774 bytes allocated
==17889== 
==17889== LEAK SUMMARY:
==17889==    definitely lost: 38 bytes in 2 blocks
==17889==    indirectly lost: 0 bytes in 0 blocks
==17889==      possibly lost: 0 bytes in 0 blocks
==17889==    still reachable: 0 bytes in 0 blocks
==17889==         suppressed: 0 bytes in 0 blocks
==17889== Rerun with --leak-check=full to see details of leaked memory
==17889== 
==17889== For counts of detected and suppressed errors, rerun with: -v
==17889== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

which happens here (c++ wrapper around libldns):
```
==6825== 24 bytes in 1 blocks are definitely lost in loss record 4 of 5
==6825==    at 0x4C2BBAF: malloc (vg_replace_malloc.c:299)
==6825==    by 0x4E78750: ldns_rdf_new_frm_data (rdata.c:203)
==6825==    by 0x4E547B5: ldns_dname_cat_clone (dname.c:83)
==6825==    by 0x4E7B935: ldns_resolver_search_status (resolver.c:1103)
==6825==    by 0x4E7BA5F: ldns_resolver_search (resolver.c:1139)
==6825==    by 0x113FC9: DnsPkt (dns_class.cpp:135)
==6825==    by 0x113FC9: Dns::query(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (dns_class.cpp:229)
==6825==    by 0x10CC9D: main (test_dns.cpp:60)
```
This happens everytime ```ldns_resolver_search``` is invoked.


With this fix:

```
valgrind --leak-check=full ldns-mx gmail.com
==3570== Memcheck, a memory error detector
==3570== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==3570== Using Valgrind-3.12.0.SVN and LibVEX; rerun with -h for copyright info
==3570== Command: ldns-mx gmail.com
==3570== 
gmail.com.      508     IN      MX      5 gmail-smtp-in.l.google.com.
gmail.com.      508     IN      MX      10 alt1.gmail-smtp-in.l.google.com.
gmail.com.      508     IN      MX      20 alt2.gmail-smtp-in.l.google.com.
gmail.com.      508     IN      MX      30 alt3.gmail-smtp-in.l.google.com.
gmail.com.      508     IN      MX      40 alt4.gmail-smtp-in.l.google.com.
==3570== 
==3570== HEAP SUMMARY:
==3570==     in use at exit: 0 bytes in 0 blocks
==3570==   total heap usage: 502 allocs, 502 frees, 615,769 bytes allocated
==3570== 
==3570== All heap blocks were freed -- no leaks are possible
==3570== 
==3570== For counts of detected and suppressed errors, rerun with: -v
==3570== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```